### PR TITLE
Fixed server crash when getting User ID without locally registered HuggingFace token

### DIFF
--- a/physical_ai_interfaces/CHANGELOG.rst
+++ b/physical_ai_interfaces/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package physical_ai_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.13 (2025-10-27)
+------------------
+* None
+
 0.6.12 (2025-10-21)
 ------------------
 * Enhanced SendTrainingCommand.srv with resume functionality.

--- a/physical_ai_interfaces/package.xml
+++ b/physical_ai_interfaces/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>physical_ai_interfaces</name>
-  <version>0.6.12</version>
+  <version>0.6.13</version>
   <description>
     ROS 2 interfaces for Physical AI tools
   </description>

--- a/physical_ai_manager/CHANGELOG.rst
+++ b/physical_ai_manager/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package physical_ai_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.13 (2025-10-27)
+------------------
+* Changed to skip automatic HF user ID loading on Record page when Push to Hub is disabled
+* Contributors: Kiwoong Park
+
 0.6.12 (2025-10-21)
 ------------------
 * Added UI features for training resume functionality.

--- a/physical_ai_manager/package-lock.json
+++ b/physical_ai_manager/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "physical_ai_manager",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "physical_ai_manager",
-      "version": "0.6.12",
+      "version": "0.6.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@reduxjs/toolkit": "^2.8.2",

--- a/physical_ai_manager/package.json
+++ b/physical_ai_manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "physical_ai_manager",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Web UI for Physical AI Platform",
   "author": "Kiwoong Park <pkw@robotis.com>",
   "contributors": [

--- a/physical_ai_manager/src/components/InfoPanel.js
+++ b/physical_ai_manager/src/components/InfoPanel.js
@@ -177,8 +177,10 @@ const InfoPanel = () => {
   }, [useMultiTaskMode, info.useOptimizedSave, dispatch]);
 
   useEffect(() => {
-    handleLoadUserId();
-  }, [handleLoadUserId]);
+    if (info.pushToHub) {
+      handleLoadUserId();
+    }
+  }, [handleLoadUserId, info.pushToHub]);
 
   useEffect(() => {
     if (userIdList.length > 0 && info.userId === undefined) {

--- a/physical_ai_manager/src/features/editDataset/components/DatasetHuggingfaceSection.js
+++ b/physical_ai_manager/src/features/editDataset/components/DatasetHuggingfaceSection.js
@@ -250,14 +250,14 @@ const HuggingfaceSection = () => {
           setUserIdList(result.user_id_list);
           toast.success('User ID list loaded successfully!');
         } else {
-          toast.error('Failed to get user ID list:\n' + result.message);
+          toast.warning('Failed to get user ID list:\n' + result.message);
         }
       } else {
-        toast.error('Failed to get user ID list from response');
+        toast.warning('Failed to get user ID list from response');
       }
     } catch (error) {
       console.error('Error loading HF user list:', error);
-      toast.error(`Failed to load user ID list: ${error.message}`);
+      toast.warning(`Failed to load user ID list: ${error.message}`);
     } finally {
       setIsLoading(false);
     }

--- a/physical_ai_manager/src/features/editDataset/components/DatasetHuggingfaceSection.js
+++ b/physical_ai_manager/src/features/editDataset/components/DatasetHuggingfaceSection.js
@@ -250,14 +250,14 @@ const HuggingfaceSection = () => {
           setUserIdList(result.user_id_list);
           toast.success('User ID list loaded successfully!');
         } else {
-          toast.warning('Failed to get user ID list:\n' + result.message);
+          toast.error('Failed to get user ID list:\n' + result.message);
         }
       } else {
-        toast.warning('Failed to get user ID list from response');
+        toast.error('Failed to get user ID list from response');
       }
     } catch (error) {
-      console.error('Error loading HF user list:', error);
-      toast.warning(`Failed to load user ID list: ${error.message}`);
+      console.warn('Error loading HF user list:', error);
+      toast.error(`Failed to load user ID list: ${error.message}`);
     } finally {
       setIsLoading(false);
     }

--- a/physical_ai_manager/src/features/editDataset/components/SectionSelector.js
+++ b/physical_ai_manager/src/features/editDataset/components/SectionSelector.js
@@ -29,7 +29,7 @@ const SectionSelector = ({
     if (canChangeSection) {
       onSectionChange(section);
     } else if (!canChangeSection && activeSection !== section) {
-      toast.warning('Cannot switch sections while upload/download is in progress');
+      toast.error('Cannot switch sections while upload/download is in progress');
     }
   };
 

--- a/physical_ai_server/CHANGELOG.rst
+++ b/physical_ai_server/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package physical_ai_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.13 (2025-10-27)
+------------------
+* Fixed physical_ai_server crash when querying user ID without locally registered HuggingFace token
+* Contributors: Kiwoong Park
+
 0.6.12 (2025-10-21)
 ------------------
 * Added training resume functionality.

--- a/physical_ai_server/package.xml
+++ b/physical_ai_server/package.xml
@@ -2,14 +2,14 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>physical_ai_server</name>
-  <version>0.6.12</version>
+  <version>0.6.13</version>
   <description>
     ROS 2 package for Open Platform AI Kit integration
   </description>
   <maintainer email="pyo@robotis.com">Pyo</maintainer>
   <license>Apache 2.0</license>
   <author email="kdy@robotis.com">Dongyun Kim</author>
-  <author email="kimsw@robotis.com">Seongwoo Kim</author>
+  <author email="kimsw@robotis.com">Seongwoo Kim</authorㄴ
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/physical_ai_server/package.xml
+++ b/physical_ai_server/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="pyo@robotis.com">Pyo</maintainer>
   <license>Apache 2.0</license>
   <author email="kdy@robotis.com">Dongyun Kim</author>
-  <author email="kimsw@robotis.com">Seongwoo Kim</authorㄴ
+  <author email="kimsw@robotis.com">Seongwoo Kim</author>
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/physical_ai_server/physical_ai_server/data_processing/data_manager.py
+++ b/physical_ai_server/physical_ai_server/data_processing/data_manager.py
@@ -524,8 +524,8 @@ class DataManager:
                     user_ids.append(org_info['name'])
                 return user_ids
             except LocalTokenNotFoundError as e:
-                print(f'No registered token found: {e}')
-                raise Exception('No registered token found')
+                print(f'No registered HuggingFace token found: {e}')
+                raise Exception('No registered HuggingFace token found')
             except Exception as e:
                 print(f'Token validation failed: {e}')
                 raise

--- a/physical_ai_server/physical_ai_server/data_processing/data_manager.py
+++ b/physical_ai_server/physical_ai_server/data_processing/data_manager.py
@@ -32,6 +32,7 @@ from huggingface_hub import (
     snapshot_download,
     upload_large_folder
 )
+from huggingface_hub.errors import LocalTokenNotFoundError
 from lerobot.datasets.utils import DEFAULT_FEATURES
 from nav_msgs.msg import Odometry
 import numpy as np
@@ -522,6 +523,9 @@ class DataManager:
                 for org_info in user_info['orgs']:
                     user_ids.append(org_info['name'])
                 return user_ids
+            except LocalTokenNotFoundError as e:
+                print(f'No registered token found: {e}')
+                raise Exception('No registered token found')
             except Exception as e:
                 print(f'Token validation failed: {e}')
                 raise

--- a/physical_ai_server/physical_ai_server/physical_ai_server.py
+++ b/physical_ai_server/physical_ai_server/physical_ai_server.py
@@ -303,7 +303,7 @@ class PhysicalAIServer(Node):
             self.get_logger().error(f'Error in set_hf_user_callback: {str(e)}')
             response.user_id_list = []
             response.success = False
-            response.message = f'Error in set_hf_user_callback: {str(e)}'
+            response.message = f'Error in set_hf_user_callback:\n{str(e)}'
             return response
 
     def get_hf_user_callback(self, request, response):
@@ -323,7 +323,7 @@ class PhysicalAIServer(Node):
             self.get_logger().error(f'Error in get_hf_user_callback: {str(e)}')
             response.user_id_list = []
             response.success = False
-            response.message = f'Failed to retrieve Hugging Face user ID: {str(e)}'
+            response.message = f'Failed to retrieve Hugging Face user ID:\n{str(e)}'
             return response
 
         return response

--- a/physical_ai_server/physical_ai_server/physical_ai_server.py
+++ b/physical_ai_server/physical_ai_server/physical_ai_server.py
@@ -298,13 +298,13 @@ class PhysicalAIServer(Node):
                 response.user_id_list = []
                 response.success = False
                 response.message = 'Failed to register token, Please check your token'
-            return response
         except Exception as e:
             self.get_logger().error(f'Error in set_hf_user_callback: {str(e)}')
             response.user_id_list = []
             response.success = False
             response.message = f'Error in set_hf_user_callback:\n{str(e)}'
-            return response
+
+        return response
 
     def get_hf_user_callback(self, request, response):
         try:
@@ -324,7 +324,6 @@ class PhysicalAIServer(Node):
             response.user_id_list = []
             response.success = False
             response.message = f'Failed to retrieve Hugging Face user ID:\n{str(e)}'
-            return response
 
         return response
 

--- a/physical_ai_server/physical_ai_server/physical_ai_server.py
+++ b/physical_ai_server/physical_ai_server/physical_ai_server.py
@@ -287,31 +287,44 @@ class PhysicalAIServer(Node):
 
     def set_hf_user_callback(self, request, response):
         request_hf_token = request.token
-        if DataManager.register_huggingface_token(request_hf_token):
-            self.get_logger().info('Hugging Face user token registered successfully')
-            response.user_id_list = DataManager.get_huggingface_user_id()
-            response.success = True
-            response.message = 'Hugging Face user token registered successfully'
-        else:
-            self.get_logger().error('Failed to register Hugging Face user token')
+        try:
+            if DataManager.register_huggingface_token(request_hf_token):
+                self.get_logger().info('Hugging Face user token registered successfully')
+                response.user_id_list = DataManager.get_huggingface_user_id()
+                response.success = True
+                response.message = 'Hugging Face user token registered successfully'
+            else:
+                self.get_logger().error('Failed to register Hugging Face user token')
+                response.user_id_list = []
+                response.success = False
+                response.message = 'Failed to register token, Please check your token'
+            return response
+        except Exception as e:
+            self.get_logger().error(f'Error in set_hf_user_callback: {str(e)}')
             response.user_id_list = []
             response.success = False
-            response.message = 'Failed to register token, Please check your token'
-        return response
+            response.message = f'Error in set_hf_user_callback: {str(e)}'
+            return response
 
     def get_hf_user_callback(self, request, response):
-        user_ids = DataManager.get_huggingface_user_id()
-        if user_ids is not None:
-            response.user_id_list = user_ids
-            self.get_logger().info(f'Hugging Face user IDs: {user_ids}')
-            response.success = True
-            response.message = 'Hugging Face user IDs retrieved successfully'
-
-        else:
-            self.get_logger().error('Failed to retrieve Hugging Face user ID')
+        try:
+            user_ids = DataManager.get_huggingface_user_id()
+            if user_ids is not None:
+                response.user_id_list = user_ids
+                self.get_logger().info(f'Hugging Face user IDs: {user_ids}')
+                response.success = True
+                response.message = 'Hugging Face user IDs retrieved successfully'
+            else:
+                self.get_logger().error('Failed to retrieve Hugging Face user ID')
+                response.user_id_list = []
+                response.success = False
+                response.message = 'Failed to retrieve Hugging Face user ID'
+        except Exception as e:
+            self.get_logger().error(f'Error in get_hf_user_callback: {str(e)}')
             response.user_id_list = []
             response.success = False
-            response.message = 'Failed to retrieve Hugging Face user ID'
+            response.message = f'Failed to retrieve Hugging Face user ID: {str(e)}'
+            return response
 
         return response
 

--- a/physical_ai_server/setup.py
+++ b/physical_ai_server/setup.py
@@ -14,7 +14,7 @@ author_emails = ', '.join(email for _, email in authors_info)
 
 setup(
     name=package_name,
-    version='0.6.12',
+    version='0.6.13',
     packages=find_packages(),
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),

--- a/physical_ai_tools/CHANGELOG.rst
+++ b/physical_ai_tools/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package physical_ai_tools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.13 (2025-10-27)
+------------------
+* Fixed physical_ai_server crash when querying user ID without locally registered HuggingFace token
+* Changed to skip automatic HF user ID loading on Record page when Push to Hub is disabled
+* Contributors: Kiwoong Park
+
 0.6.12 (2025-10-21)
 ------------------
 * Enhanced SendTrainingCommand.srv with resume functionality.

--- a/physical_ai_tools/package.xml
+++ b/physical_ai_tools/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>physical_ai_tools</name>
-  <version>0.6.12</version>
+  <version>0.6.13</version>
   <description>
     physical_ai_tools meta ROS 2 package
   </description>


### PR DESCRIPTION
### Changes

physical ai server
* Changed to skip automatic HF user ID loading on Record page when Push to Hub is disabled

physical ai manager
* Changed to skip automatic HF user ID loading on Record page when Push to Hub is disabled