### PR TITLE
Remove ros rolling ci workflows

### DIFF
--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -19,7 +19,7 @@ jobs:
         ros_distribution:
           # - humble
           - jazzy
-          - rolling
+          # - rolling
         include:
           # ROS 2 Humble Hawksbill
           # - docker_image: ubuntu:jammy
@@ -30,9 +30,9 @@ jobs:
             ros_distribution: jazzy
             ros_version: 2
           # ROS 2 Rolling Ridley
-          - docker_image: ubuntu:resolute
-            ros_distribution: rolling
-            ros_version: 2
+          # - docker_image: ubuntu:resolute
+          #   ros_distribution: rolling
+          #   ros_version: 2
     container:
       image: ${{ matrix.docker_image }}
     steps:

--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -30,7 +30,7 @@ jobs:
             ros_distribution: jazzy
             ros_version: 2
           # ROS 2 Rolling Ridley
-          - docker_image: ubuntu:noble
+          - docker_image: ubuntu:resolute
             ros_distribution: rolling
             ros_version: 2
     container:

--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -45,7 +45,7 @@ jobs:
           path: ros_ws/src
 
       - name: Setup ROS environment
-        uses: ros-tooling/setup-ros@v0.7
+        uses: ros-tooling/setup-ros@v0.7.15
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 

--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -45,7 +45,7 @@ jobs:
           path: ros_ws/src
 
       - name: Setup ROS environment
-        uses: ros-tooling/setup-ros@v0.7.15
+        uses: ros-tooling/setup-ros@0.7.15
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 

--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -45,7 +45,7 @@ jobs:
           path: ros_ws/src
 
       - name: Setup ROS environment
-        uses: ros-tooling/setup-ros@0.7.15
+        uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 


### PR DESCRIPTION

the release platform in the ROS Rolling `distribution.yaml` was changed to Ubuntu Resolute.
https://github.com/ros/rosdistro/commit/9c59da1d72a2407a545f8fa5885b71676b972915

As a result, Rolling CI can no longer install Rolling ROS packages through rosdep in a Noble environment, so the Rolling CI container in our GitHub workflows needs to be migrated from Ubuntu Noble to Ubuntu Resolute.

However, starting from Ubuntu Resolute, the `apt-key` command has been completely removed (up to Ubuntu 24.04 it only showed a deprecation warning).

The `setup-ros` action from ros-tooling that we use in CI still uses `apt-key`, including both the latest release version and the current main branch.

Because of this, CI cannot currently run in an Ubuntu Resolute environment.

SO we have decided to remove the ROS Rolling CI for now.